### PR TITLE
Implement CSRF Cookie Fetching in API Service

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,6 +1,6 @@
 // API utilities for Laravel backend integration
 
-import { httpDelete, httpGet, httpPatch, httpPost, httpPut } from "@/lib/http"
+import { fetchCsrfCookie, httpDelete, httpGet, httpPatch, httpPost, httpPut } from "@/lib/http"
 import type { Notification, Schedule, PointOfInterest, User } from "@/lib/types"
 
 export interface PilgrimRegistration {
@@ -37,6 +37,7 @@ export const apiService = {
   },
 
   async getPilgrimRegistrations(): Promise<ApiResponse<PilgrimRegistration[]>> {
+    await fetchCsrfCookie()
     const items = await httpGet<PilgrimRegistration[]>("/api/pilgrims", { withCredentials: true })
     return {
       data: items,
@@ -49,6 +50,7 @@ export const apiService = {
     id: string,
     status: PilgrimRegistration["status"],
   ): Promise<ApiResponse<PilgrimRegistration>> {
+    await fetchCsrfCookie()
     const updated = await httpPatch<PilgrimRegistration>(`/api/pilgrims/${id}`, { status }, { withCredentials: true })
     return {
       data: updated,
@@ -58,20 +60,24 @@ export const apiService = {
   },
 
   async deletePilgrim(id: string): Promise<ApiResponse<null>> {
+    await fetchCsrfCookie()
     await httpDelete<unknown>(`/api/pilgrims/${id}`, { withCredentials: true })
     return { data: null, success: true, message: "Pèlerin supprimé" }
   },
 
   // Users (admin)
   async getUsers(): Promise<ApiResponse<User[]>> {
+    await fetchCsrfCookie()
     const items = await httpGet<User[]>("/api/users", { withCredentials: true })
     return { data: items, success: true, message: "Utilisateurs récupérés" }
   },
   async updateUser(id: string, data: Partial<Pick<User, "role">> & { status?: "active" | "inactive" | "suspended"; name?: string }) {
+    await fetchCsrfCookie()
     const updated = await httpPatch<User>(`/api/users/${id}`, data, { withCredentials: true })
     return { data: updated, success: true, message: "Utilisateur mis à jour" }
   },
   async deleteUser(id: string) {
+    await fetchCsrfCookie()
     await httpDelete(`/api/users/${id}`, { withCredentials: true })
     return { data: null, success: true, message: "Utilisateur supprimé" }
   },
@@ -92,6 +98,7 @@ export const apiService = {
       location: data.location,
       type: data.type,
     }
+    await fetchCsrfCookie()
     const created = await httpPost<Schedule>("/api/schedules", payload, { withCredentials: true })
     return { data: created, success: true, message: "Horaire créé" }
   },
@@ -104,10 +111,12 @@ export const apiService = {
     if (data.endTime !== undefined) payload.end_time = data.endTime
     if (data.location !== undefined) payload.location = data.location
     if (data.type !== undefined) payload.type = data.type
+    await fetchCsrfCookie()
     const updated = await httpPut<Schedule>(`/api/schedules/${id}`, payload, { withCredentials: true })
     return { data: updated, success: true, message: "Horaire mis à jour" }
   },
   async deleteSchedule(id: string) {
+    await fetchCsrfCookie()
     await httpDelete(`/api/schedules/${id}`, { withCredentials: true })
     return { data: null, success: true, message: "Horaire supprimé" }
   },
@@ -119,16 +128,19 @@ export const apiService = {
   },
 
   async sendNotification(data: Pick<Notification, "title" | "message" | "type">): Promise<ApiResponse<Notification>> {
+    await fetchCsrfCookie()
     const created = await httpPost<Notification>("/api/notifications", data, { withCredentials: true })
     return { data: created, success: true, message: "Notification envoyée" }
   },
 
   async updateNotification(id: string, data: Partial<Notification>) {
+    await fetchCsrfCookie()
     const updated = await httpPut<Notification>(`/api/notifications/${id}`, data, { withCredentials: true })
     return { data: updated, success: true, message: "Notification mise à jour" }
   },
 
   async deleteNotification(id: string) {
+    await fetchCsrfCookie()
     await httpDelete(`/api/notifications/${id}`, { withCredentials: true })
     return { data: null, success: true, message: "Notification supprimée" }
   },
@@ -139,15 +151,21 @@ export const apiService = {
     return { data: items, success: true, message: "Points d'intérêt récupérés" }
   },
   async createPointOfInterest(data: Omit<PointOfInterest, "id">) {
+    await fetchCsrfCookie()
     const created = await httpPost<PointOfInterest>("/api/points-of-interest", data, { withCredentials: true })
     return { data: created, success: true, message: "Point d'intérêt créé" }
   },
   async updatePointOfInterest(id: string, data: Partial<PointOfInterest>) {
+    await fetchCsrfCookie()
     const updated = await httpPut<PointOfInterest>(`/api/points-of-interest/${id}`, data, { withCredentials: true })
     return { data: updated, success: true, message: "Point d'intérêt mis à jour" }
   },
   async deletePointOfInterest(id: string) {
+    await fetchCsrfCookie()
     await httpDelete(`/api/points-of-interest/${id}`, { withCredentials: true })
+    return { data: null, success: true, message: "Point d'intérêt supprimé" }
+  },
+}`, { withCredentials: true })
     return { data: null, success: true, message: "Point d'intérêt supprimé" }
   },
 }


### PR DESCRIPTION
This pull request modifies the API service by including a call to `fetchCsrfCookie()` before making any HTTP requests. This is implemented in several methods such as getting, updating, and deleting pilgrims, users, schedules, notifications, and points of interest. The addition of this function ensures that CSRF tokens are properly fetched for enhanced security when interacting with the Laravel backend, thereby solving issues related to possible CSRF attacks.

---

> This pull request was co-created with Cosine Genie

Original Task: [MekteMi/a5qht4qh69oa](https://cosine.sh/03wn3ckcoqao/MekteMi/task/a5qht4qh69oa)
Author: Cheikh Gadji
